### PR TITLE
Feature/95 translation serializer bug

### DIFF
--- a/src/openproduct/producttypen/tests/api/test_content.py
+++ b/src/openproduct/producttypen/tests/api/test_content.py
@@ -68,6 +68,21 @@ class TestContentElement(BaseApiTestCase):
         }
         self.assertEqual(response.data, expected_data)
 
+    def test_create_content_element_with_language_header(self):
+
+        for header in [{"Accept-Language": "en"}, {"Content-Language": "en"}]:
+            with self.subTest(f"{header} should set default language only"):
+                response = self.client.post(self.path, self.data, headers=header)
+
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                self.assertEqual(response.data["taal"], "nl")
+                self.assertEqual(response.data["content"], self.data["content"])
+                self.assertEqual(response.headers["Content-Language"], "nl")
+
+                element = ContentElement.objects.get(uuid=response.data["uuid"])
+                element.set_current_language("nl")
+                self.assertEqual(element.content, self.data["content"])
+
     def test_update_content_element(self):
         data = self.data | {"content": "update"}
         response = self.client.put(self.detail_path, data)
@@ -75,6 +90,21 @@ class TestContentElement(BaseApiTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ContentElement.objects.count(), 1)
         self.assertEqual(ContentElement.objects.get().content, "update")
+
+    def test_update_content_element_with_language_header(self):
+
+        for header in [{"Accept-Language": "en"}, {"Content-Language": "en"}]:
+            with self.subTest(f"{header} should set default language only"):
+                response = self.client.put(self.detail_path, self.data, headers=header)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["taal"], "nl")
+                self.assertEqual(response.data["content"], self.data["content"])
+                self.assertEqual(response.headers["Content-Language"], "nl")
+
+                element = ContentElement.objects.get(uuid=response.data["uuid"])
+                element.set_current_language("nl")
+                self.assertEqual(element.content, self.data["content"])
 
     def test_partial_update_content_element(self):
         data = {"content": "update"}

--- a/src/openproduct/producttypen/tests/api/test_producttype.py
+++ b/src/openproduct/producttypen/tests/api/test_producttype.py
@@ -157,6 +157,23 @@ class TestProducttypeViewSet(BaseApiTestCase):
         }
         self.assertEqual(response.data, expected_data)
 
+    def test_create_producttype_with_language_header(self):
+
+        for header in [{"Accept-Language": "en"}, {"Content-Language": "en"}]:
+            with self.subTest(f"{header} should set default language only"):
+                response = self.client.post(
+                    self.path, self.data | {"code": str(header)}, headers=header
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                self.assertEqual(response.data["taal"], "nl")
+                self.assertEqual(response.data["naam"], self.data["naam"])
+                self.assertEqual(response.headers["Content-Language"], "nl")
+
+                producttype = ProductType.objects.get(uuid=response.data["uuid"])
+                producttype.set_current_language("nl")
+                self.assertEqual(producttype.naam, self.data["naam"])
+
     def test_create_producttype_without_thema_returns_error(self):
         data = self.data.copy()
         data["thema_uuids"] = []
@@ -604,6 +621,26 @@ class TestProducttypeViewSet(BaseApiTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(ProductType.objects.count(), 1)
+
+    def test_update_producttype_with_language_header(self):
+
+        for header in [{"Accept-Language": "en"}, {"Content-Language": "en"}]:
+            with self.subTest(f"{header} should set default language only"):
+                producttype = ProductTypeFactory.create()
+                response = self.client.put(
+                    self.detail_path(producttype),
+                    self.data | {"code": str(header)},
+                    headers=header,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["taal"], "nl")
+                self.assertEqual(response.data["naam"], self.data["naam"])
+                self.assertEqual(response.headers["Content-Language"], "nl")
+
+                producttype = ProductType.objects.get(uuid=response.data["uuid"])
+                producttype.set_current_language("nl")
+                self.assertEqual(producttype.naam, self.data["naam"])
 
     def test_update_producttype_with_thema(self):
         producttype = ProductTypeFactory.create()

--- a/src/openproduct/producttypen/viewsets/content.py
+++ b/src/openproduct/producttypen/viewsets/content.py
@@ -1,3 +1,5 @@
+from django.utils.translation import activate
+
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins
@@ -43,6 +45,14 @@ class ContentElementViewSet(
     queryset = ContentElement.objects.all()
     serializer_class = ContentElementSerializer
     lookup_field = "uuid"
+
+    def initial(self, request, *args, **kwargs):
+        # passing the translated fields to  the create call will set them for the language in the Accept-Language header.
+        # but a POST/PUT/PATCH should only set the required language
+        # (other languages can be added in the vertaling viewset action)
+        if self.action in ["create", "update", "partial_update"]:
+            activate("nl")
+        return super().initial(request, *args, **kwargs)
 
     @extend_schema(
         summary="De vertaling van een content element aanpassen.",

--- a/src/openproduct/producttypen/viewsets/producttype.py
+++ b/src/openproduct/producttypen/viewsets/producttype.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import activate, gettext_lazy as _
 
 import django_filters
 from drf_spectacular.types import OpenApiTypes
@@ -167,6 +167,14 @@ class ProductTypeViewSet(
     serializer_class = ProductTypeSerializer
     lookup_field = "uuid"
     filterset_class = ProductTypeFilterSet
+
+    def initial(self, request, *args, **kwargs):
+        # passing the translated fields to  the create call will set them for the language in the Accept-Language header.
+        # but a POST/PUT/PATCH should only set the required language
+        # (other languages can be added in the vertaling viewset action)
+        if self.action in ["create", "update", "partial_update"]:
+            activate("nl")
+        return super().initial(request, *args, **kwargs)
 
     def get_serializer_context(self):
         context = super().get_serializer_context()


### PR DESCRIPTION
Fixes #95

**Changes**
- fixes issue with the serializers that have translations, The accept language header in the request was used to save translation fields which should not happen.

