### PR TITLE
change translation filter to nl only

### DIFF
--- a/src/openproduct/producten/viewsets/product.py
+++ b/src/openproduct/producten/viewsets/product.py
@@ -61,7 +61,7 @@ class ProductFilterSet(FilterSet):
     producttype__naam = TranslationFilter(
         field_name="producttype__naam",
         lookup_expr="exact",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     dataobject_attr = ManyCharFilter(
@@ -78,7 +78,7 @@ class ProductFilterSet(FilterSet):
 
     producttype__naam__in = TranslationInFilter(
         field_name="producttype__naam",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     eigenaren__bsn = django_filters.CharFilter(

--- a/src/openproduct/producttypen/tests/api/test_producttype_filters.py
+++ b/src/openproduct/producttypen/tests/api/test_producttype_filters.py
@@ -201,7 +201,7 @@ class TestProductTypeFilters(BaseApiTestCase):
             producttype_2.save()
 
             response = self.client.get(
-                self.path, {"letter": "q"}, headers={"Accept-Language": "en"}
+                self.path, {"letter": "A"}, headers={"Accept-Language": "en"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/src/openproduct/producttypen/viewsets/actie.py
+++ b/src/openproduct/producttypen/viewsets/actie.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 import django_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.viewsets import ModelViewSet
@@ -19,7 +21,7 @@ class ActieFilterSet(FilterSet):
     producttype__naam = TranslationFilter(
         field_name="producttype__naam",
         lookup_expr="exact",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     class Meta:

--- a/src/openproduct/producttypen/viewsets/bestand.py
+++ b/src/openproduct/producttypen/viewsets/bestand.py
@@ -27,7 +27,7 @@ class BestandFilterSet(FilterSet):
     producttype__naam = TranslationFilter(
         field_name="producttype__naam",
         lookup_expr="exact",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     class Meta:

--- a/src/openproduct/producttypen/viewsets/link.py
+++ b/src/openproduct/producttypen/viewsets/link.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 import django_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.viewsets import ModelViewSet
@@ -19,7 +21,7 @@ class LinkFilterSet(FilterSet):
     producttype__naam = TranslationFilter(
         field_name="producttype__naam",
         lookup_expr="exact",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     class Meta:

--- a/src/openproduct/producttypen/viewsets/prijs.py
+++ b/src/openproduct/producttypen/viewsets/prijs.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 import django_filters
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.viewsets import ModelViewSet
@@ -19,7 +21,7 @@ class PrijsFilterSet(FilterSet):
     producttype__naam = TranslationFilter(
         field_name="producttype__naam",
         lookup_expr="exact",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     def filter_queryset(self, queryset):

--- a/src/openproduct/producttypen/viewsets/producttype.py
+++ b/src/openproduct/producttypen/viewsets/producttype.py
@@ -63,16 +63,14 @@ class ProductTypeFilterSet(FilterSet):
         field_name="naam",
         lookup_expr="istartswith",
         help_text=_(
-            _(
-                "Filter op de eerste letter van de naam van het producttype (in de meegegeven `Accept-Language` taal)."
-            ),
+            _("Filter op de eerste letter van de Nederlandse naam van het producttype"),
         ),
     )
 
     naam = TranslationFilter(
         field_name="naam",
         lookup_expr="exact",
-        help_text=get_help_text("producttypen.ProductTypeTranslation", "naam"),
+        help_text=_("De Nederlandse naam van het producttype"),
     )
 
     keywords = CharArrayFilter(

--- a/src/openproduct/utils/filters.py
+++ b/src/openproduct/utils/filters.py
@@ -95,9 +95,7 @@ class TranslationFilter(django_filters.CharFilter):
             lookup = f"{self.model_field_name}__{lookup}"
             language_lookup = f"{self.model_field_name}__{language_lookup}"
 
-        language_code = self.parent.request.LANGUAGE_CODE
-
-        qs = self.get_method(qs)(**{lookup: value, language_lookup: language_code})
+        qs = self.get_method(qs)(**{lookup: value, language_lookup: "nl"})
         return qs
 
 

--- a/src/producten-openapi.yaml
+++ b/src/producten-openapi.yaml
@@ -235,14 +235,14 @@ paths:
         name: producttype__naam
         schema:
           type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
       - in: query
         name: producttype__naam__in
         schema:
           type: array
           items:
             type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
         explode: false
         style: form
       - in: query

--- a/src/producttypen-openapi.yaml
+++ b/src/producttypen-openapi.yaml
@@ -132,7 +132,7 @@ paths:
         name: producttype__naam
         schema:
           type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
       - in: query
         name: producttype__uuid
         schema:
@@ -624,7 +624,7 @@ paths:
         name: producttype__naam
         schema:
           type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
       - in: query
         name: producttype__uuid
         schema:
@@ -1872,7 +1872,7 @@ paths:
         name: producttype__naam
         schema:
           type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
       - in: query
         name: producttype__uuid
         schema:
@@ -3115,7 +3115,7 @@ paths:
         name: producttype__naam
         schema:
           type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
       - in: query
         name: producttype__uuid
         schema:
@@ -3744,13 +3744,12 @@ paths:
         name: letter
         schema:
           type: string
-        description: Filter op de eerste letter van de naam van het producttype (in
-          de meegegeven `Accept-Language` taal).
+        description: Filter op de eerste letter van de Nederlandse naam van het producttype
       - in: query
         name: naam
         schema:
           type: string
-        description: naam van het producttype.
+        description: De Nederlandse naam van het producttype
       - name: page
         required: false
         in: query


### PR DESCRIPTION
Fixes #173

**Changes**
- changes producttype naam filter to nl only, (response can still be in en based on accept-language)

