### PR TITLE
:bug: [#239] Fix help texts do not have horizontal space

### DIFF
--- a/src/openproduct/patches/django_otp_admin.py
+++ b/src/openproduct/patches/django_otp_admin.py
@@ -1,0 +1,28 @@
+from django.contrib import admin
+
+from django_otp.plugins.otp_static.admin import StaticDeviceAdmin
+from django_otp.plugins.otp_static.models import StaticDevice
+from django_otp.plugins.otp_totp.admin import TOTPDeviceAdmin
+from django_otp.plugins.otp_totp.models import TOTPDevice
+
+from openproduct.utils.admin import user_model_search_fields_nl
+
+fields, help_text = user_model_search_fields_nl(["username", "email"])
+
+
+admin.site.unregister(TOTPDevice)
+
+
+@admin.register(TOTPDevice)
+class DutchTOTPDeviceAdmin(TOTPDeviceAdmin):
+    search_fields = fields
+    search_help_text = help_text
+
+
+admin.site.unregister(StaticDevice)
+
+
+@admin.register(StaticDevice)
+class DutchStaticDeviceAdmin(StaticDeviceAdmin):
+    search_fields = fields
+    search_help_text = help_text

--- a/src/openproduct/producttypen/apps.py
+++ b/src/openproduct/producttypen/apps.py
@@ -10,6 +10,7 @@ class ProducttypenConfig(AppConfig):
     def ready(self):
         # load the signal receivers
         from . import signals  # noqa
+        import openproduct.patches.django_otp_admin  # noqa
 
         unregister_camelize_filter_extension()
 

--- a/src/openproduct/scss/admin/_admin_theme.scss
+++ b/src/openproduct/scss/admin/_admin_theme.scss
@@ -294,3 +294,13 @@ div:has(> div.help ) {
   display: inline-block;
   margin-left: inherit !important;
 }
+/* Fix inline help text being squeezed into 14px */
+div.help:not(:has(> div)) {
+  inline-size: auto !important;
+  block-size: auto !important;
+  background: none !important;
+}
+
+#changelist-search .help {
+  word-break: normal !important;
+}


### PR DESCRIPTION
Fixes #239

**Changes**

- Fix horizontal spacing for help texts
- Add translations for help texts

<img width="493" height="114" alt="image" src="https://github.com/user-attachments/assets/1b68b6f8-9956-4aaa-a18b-691507e9c040" />

