### PR TITLE
:arrow_up: Upgrade to ubuntu 24.04 for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 


### PR DESCRIPTION
Because building with 20.04 for Readthedocs will be deprecated soon