### PR TITLE
:construction_worker: [maykinmedia/open-api-workflows#60] Reenable OAS workflow and replace spectral with vacuum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         id: image-name
 
   open-api-ci:
-    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
     permissions:
@@ -115,7 +115,7 @@ jobs:
       django-settings-module: openproduct.conf.ci
 
   open-api-publish:
-    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
       - open-api-ci

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   open-api-workflow-code-quality:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       python-version: '3.12'
       node-version: '24'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   open-api-workflow-code-analysis:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0

--- a/.github/workflows/oaf-check.yml
+++ b/.github/workflows/oaf-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   open-api-workflow-check-oas:
-    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
 
     with:
       python-version: '3.12'

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,39 +1,39 @@
-# name: OAS
+name: OAS
 
-# on:
-#   push:
-#     branches:
-#       - master
-#       - stable/*
-#     tags:
-#       - '*'
-#   pull_request:
-#   workflow_dispatch:
+on:
+  push:
+    branches:
+      - master
+      - stable/*
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
 
-# # least privilege as default, should be overridden per job if necessary
-# permissions:
-#   contents: read
+# least privilege as default, should be overridden per job if necessary
+permissions:
+  contents: read
 
-# jobs:
-#   oas:
-#     name: Checks
+jobs:
+  oas:
+    name: Checks
 
-#     strategy:
-#       matrix:
-#         component:
-#           - producten
-#           - producttypen
+    strategy:
+      matrix:
+        component:
+          - producten
+          - producttypen
 
-#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-#     with:
-#       python-version: '3.12'
-#       django-settings-module: openproduct.conf.ci
-#       oas-generate-command: bin/generate_api_schema.sh
-#       schema-path: src/${{ matrix.component }}-openapi.yaml
-#       oas-artifact-name: ${{ matrix.component }}-api-oas
-#       node-version-file: '.nvmrc'
-#       spectral-version: '^6.15.0'
-#       openapi-to-postman-version: '^5.0.0'
-#       postman-artifact-name: ${{ matrix.component }}-api-postman-collection
-#       openapi-generator-version: '^2.20.0'
-#       spectral-ruleset: ruleset.yaml
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
+    with:
+      python-version: '3.12'
+      django-settings-module: openproduct.conf.ci
+      oas-generate-command: bin/generate_api_schema.sh
+      schema-path: src/${{ matrix.component }}-openapi.yaml
+      oas-artifact-name: ${{ matrix.component }}-api-oas
+      node-version-file: '.nvmrc'
+      openapi-to-postman-version: '^5.0.0'
+      postman-artifact-name: ${{ matrix.component }}-api-postman-collection
+      openapi-generator-version: '^2.20.0'
+      spectral-ruleset: ruleset.yaml
+      vacuum-custom-functions: vacuum_functions

--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   open-api-workflow-quick-start:
-    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       fixtures: 'demodata'

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,5 +1,8 @@
 # 2.1 ruleset got changed without a version increase
-extends: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml
+# vacuum supports the extends syntax and can fetch external rulesets, but the original
+# URL (https://static.developer.overheid.nl/adr/2.1/ruleset.yaml) returns the linter as
+# a file download, which vacuum doesn't support currently
+extends: https://raw.githubusercontent.com/Logius-standaarden/API-Design-Rules/refs/tags/v2.1.0/linter/spectral.yml
 rules:
   paths-open-api-json-resource-exists: warn
   # Workaround for https://github.com/open-zaak/open-zaak/issues/2390

--- a/src/openproduct/producttypen/viewsets/producttype.py
+++ b/src/openproduct/producttypen/viewsets/producttype.py
@@ -5,6 +5,7 @@ from django.utils.translation import activate, gettext_lazy as _
 
 import django_filters
 import structlog
+from drf_spectacular.plumbing import build_choice_description_list
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -253,7 +254,24 @@ class Meta:
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.HEADER,
                 description="Optionele taal (`nl, `en`).",
-            )
+            ),
+            OpenApiParameter(
+                name="toegestane_statussen",
+                type={
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [choice[0] for choice in ProductStateChoices.choices],
+                    },
+                },
+                location=OpenApiParameter.QUERY,
+                description="{}\n\n{}".format(
+                    get_help_text("producttypen.ProductType", "toegestane_statussen"),
+                    build_choice_description_list(ProductStateChoices.choices),
+                ),
+                explode=False,
+                style="form",
+            ),
         ],
     ),
     retrieve=extend_schema(

--- a/src/producttypen-openapi.yaml
+++ b/src/producttypen-openapi.yaml
@@ -5175,30 +5175,14 @@ paths:
         schema:
           type: array
           items:
-            type: array
-            items:
-              enum:
-              - in_aanvraag
-              - gereed
-              - actief
-              - ingetrokken
-              - geweigerd
-              - verlopen
-              type: string
-              description: |-
-                * `in_aanvraag` - In aanvraag
-                * `gereed` - Gereed
-                * `actief` - Actief
-                * `ingetrokken` - Ingetrokken
-                * `geweigerd` - Geweigerd
-                * `verlopen` - Verlopen
+            type: string
             enum:
-            - actief
-            - gereed
-            - geweigerd
-            - in_aanvraag
-            - ingetrokken
             - initieel
+            - in_aanvraag
+            - gereed
+            - actief
+            - ingetrokken
+            - geweigerd
             - verlopen
         description: |-
           toegestane statussen voor producten van dit type.

--- a/vacuum_functions/or.js
+++ b/vacuum_functions/or.js
@@ -1,0 +1,24 @@
+// The Logius API design rules make use of the function `or`, which vacuum does not
+// support
+function getSchema() {
+  return {
+    name: "or",
+    description: "Passes if any configured property exists."
+  };
+}
+
+function runRule(input) {
+  const properties = context.rule.then.functionOptions.properties || [];
+
+  for (const property of properties) {
+    if (Object.prototype.hasOwnProperty.call(input, property)) {
+      return [];
+    }
+  }
+
+  return [
+    {
+      message: "None of the required properties were found."
+    }
+  ];
+}


### PR DESCRIPTION
Fixes maykinmedia/open-api-workflows#60 partially

**Changes**

* Reenable OAS workflow and replace spectral with vacuum

**Checklist**

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/maykinmedia/open-product/wiki/Architectural-Decision-Records-(ADR))
