### PR TITLE
:bug: [#348] fix validate_product_status to show error for non existent statussen.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ linkcheck_ignore = [
     r"http://localhost:\d+,https?://.*\.gemeente.nl",
     r"https://github.com/maykinmedia/open-product/blob/master/README.EN.rst#.*",
     r"https://opentelemetry.io/.*",
+    r"https://sentry.io/",
 ]
 
 sphinx_tabs_valid_builders = ["linkcheck"]

--- a/src/openproduct/producten/models/validators.py
+++ b/src/openproduct/producten/models/validators.py
@@ -53,7 +53,7 @@ def validate_product_status(status, producttype):
                 "status": _(
                     "Status '{}' is niet toegestaan voor het producttype {}."
                 ).format(
-                    ProductStateChoices(status).label,
+                    status,
                     producttype.naam,
                 )
             }

--- a/src/openproduct/producten/tests/api/test_product.py
+++ b/src/openproduct/producten/tests/api/test_product.py
@@ -157,6 +157,33 @@ class TestProduct(BaseApiTestCase):
         }
         self.assertEqual(response.data, expected_data)
 
+    def test_create_product_without_status(self):
+        self.data.pop("status")
+        response = self.client.post(self.path, self.data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            _("Status 'None' is niet toegestaan voor het producttype {}.").format(
+                self.producttype.naam
+            ),
+        )
+
+    def test_create_product_with_non_existent_status(self):
+        response = self.client.post(self.path, self.data | {"status": "in aanvraag"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "status")
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid_choice")
+        self.assertEqual(
+            error["reason"],
+            _('"in aanvraag" is een ongeldige keuze.'),
+        )
+
     def test_create_product_with_verbruiksobject(self):
         json_schema = JsonSchemaFactory.create(
             schema={
@@ -446,7 +473,7 @@ class TestProduct(BaseApiTestCase):
         self.assertEqual(error["code"], "invalid")
         self.assertEqual(
             error["reason"],
-            _("Status 'Actief' is niet toegestaan voor het producttype {}.").format(
+            _("Status 'actief' is niet toegestaan voor het producttype {}.").format(
                 self.producttype.naam
             ),
         )
@@ -738,7 +765,7 @@ class TestProduct(BaseApiTestCase):
         self.assertEqual(error["code"], "invalid")
         self.assertEqual(
             error["reason"],
-            _("Status 'Actief' is niet toegestaan voor het producttype {}.").format(
+            _("Status 'actief' is niet toegestaan voor het producttype {}.").format(
                 self.producttype.naam
             ),
         )
@@ -1718,7 +1745,7 @@ class TestProduct(BaseApiTestCase):
                 "field": {"status": "gereed"},
                 "param": "status",
                 "reason": _(
-                    "Status 'Gereed' is niet toegestaan voor het producttype {}."
+                    "Status 'gereed' is niet toegestaan voor het producttype {}."
                 ).format(new_producttype.naam),
             },
             {
@@ -1774,7 +1801,7 @@ class TestProduct(BaseApiTestCase):
                 "field": {"status": "gereed"},
                 "param": "status",
                 "reason": _(
-                    "Status 'Gereed' is niet toegestaan voor het producttype {}."
+                    "Status 'gereed' is niet toegestaan voor het producttype {}."
                 ).format(producttype.naam),
             },
             {

--- a/src/openproduct/producten/tests/test_product.py
+++ b/src/openproduct/producten/tests/test_product.py
@@ -186,7 +186,7 @@ class TestProductValidateMethods(TestCase):
 
         with self.assertRaisesMessage(
             ValidationError,
-            _("Status 'Gereed' is niet toegestaan voor het producttype {}.").format(
+            _("Status 'gereed' is niet toegestaan voor het producttype {}.").format(
                 producttype.naam
             ),
         ):

--- a/src/openproduct/producttypen/tests/api/test_producttype.py
+++ b/src/openproduct/producttypen/tests/api/test_producttype.py
@@ -269,6 +269,32 @@ class TestProducttypeViewSet(BaseApiTestCase):
         self.assertEqual(ProductType.objects.count(), 1)
         self.assertEqual(response.data["toegestane_statussen"], ["gereed"])
 
+    def test_create_producttype_with_non_existent_toegestane_statussen(self):
+        response = self.client.post(
+            self.path, self.data | {"toegestane_statussen": ["in aanvraag"]}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "toegestane_statussen.")
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid_choice")
+        self.assertEqual(
+            error["reason"],
+            _('"in aanvraag" is een ongeldige keuze.'),
+        )
+
+    def test_create_producttype_with_None_toegestane_statussen(self):
+        response = self.client.post(
+            self.path, self.data | {"toegestane_statussen": [None]}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "toegestane_statussen.")
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "null")
+        self.assertEqual(
+            error["reason"],
+            _("Dit veld mag niet leeg zijn."),
+        )
+
     def test_create_producttype_with_duplicate_externe_code_systemen_returns_error(
         self,
     ):


### PR DESCRIPTION
Fixes #348

- fixes validate_product_status

[Describe the changes here]

**Checklist**

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/maykinmedia/open-product/wiki/Architectural-Decision-Records-(ADR))
